### PR TITLE
Restart timesyncd after ntp server change

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,9 @@
     owner: root
     group: root
     mode: 0644
-  notify: run timedatectl
+  notify:
+    - run timedatectl
+    - restart timesyncd
   when: ansible_service_mgr == "systemd"
 
 - name: Enable and run systemd-timesyncd


### PR DESCRIPTION
Fixes the problem that timesyncd does not use the new ntp servers after a config change